### PR TITLE
feat: add rectangle tracker based on EKF and 

### DIFF
--- a/src/EKF.py
+++ b/src/EKF.py
@@ -38,10 +38,10 @@ class ExtendedKalmanFilter():
         """
         if B is None:
             x_ = A @ self.x
-            P_ = A @ self.P @ self.A.T + Q
+            P_ = A @ self.P @ A.T + Q
         else:
             x_ = A @ self.x + B @ u
-            P_ = A @ self.P @ self.A.T + Q + B @ q_u @ B.T
+            P_ = A @ self.P @ A.T + Q + B @ q_u @ B.T
         return x_, P_
         
 

--- a/src/EKF.py
+++ b/src/EKF.py
@@ -37,7 +37,7 @@ class ExtendedKalmanFilter():
             x_, P_ : Predicted state and covariance
         """
         if B is None:
-            x_ = A @ self,x
+            x_ = A @ self.x
             P_ = A @ self.P @ self.A.T + Q
         else:
             x_ = A @ self.x + B @ u
@@ -45,7 +45,7 @@ class ExtendedKalmanFilter():
         return x_, P_
         
 
-    def predict_nonlinear(self, F_func, Q, Jacob_F = None, *other_arg):
+    def predict_nonlinear(self, F_func, Q, Jacob_F = None, **other_args):
         """General Prediction
 
         Args:
@@ -59,11 +59,11 @@ class ExtendedKalmanFilter():
         """
 
         if Jacob_F is None:
-            J_F = numerical_grad(F_func, self.x, *other_arg)# numerical grad to calc jacobian
+            J_F = numerical_jacob(F_func, self.x, **other_args)# numerical grad to calc jacobian
         else:
-            J_F = Jacob_F(self.x, *other_arg)
+            J_F = Jacob_F(self.x, **other_args)
 
-        x_ = F_func(self.x, *other_arg)
+        x_ = F_func(self.x, **other_args)
         P_ = J_F @ self.P @ J_F.T + Q
         return x_, P_
 
@@ -83,7 +83,7 @@ class ExtendedKalmanFilter():
         self.x = x_ + K @ err
         self.P = (np.eye(P_.shape[0]) - K @ C) @ P_
 
-    def update_nonlinear(self, x_, P_, H_func, z, R, H_jacob=None, *other_args):
+    def update_nonlinear(self, x_, P_, H_func, z, R, H_jacob=None, **other_args):
         """Non Linear Update
 
         Args:
@@ -98,11 +98,11 @@ class ExtendedKalmanFilter():
 
 
         if H_jacob is None:
-            J_H = numerical_jacob(H_func,x_,*other_args)
+            J_H = numerical_jacob(H_func,x_,**other_args)
         else:
-            J_H = H_jacob(x_, *other_args)
+            J_H = H_jacob(x_, **other_args)
         
-        err = z - H_func(x_, *other_args)
+        err = z - H_func(x_, **other_args)
         S = J_H @ P_ @ J_H.T + R
         K = P_ @ J_H.T @ np.linalg.inv(S)
         self.x = x_ + K @ err

--- a/src/EKF.py
+++ b/src/EKF.py
@@ -102,7 +102,8 @@ class ExtendedKalmanFilter():
         else:
             J_H = H_jacob(x_, **other_args)
         
-        err = z - H_func(x_, **other_args)
+        z_est = H_func(x_, **other_args) # separated for debugging
+        err = z - z_est
         S = J_H @ P_ @ J_H.T + R
         K = P_ @ J_H.T @ np.linalg.inv(S)
         self.x = x_ + K @ err

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -11,7 +11,6 @@ import math
 import random
 
 from utils import rot_mat_2d
-from tracker.LshapeFitting import LShapeFitting
 
 
 LIDAR_NOISE_SIGMA = 0.01
@@ -180,6 +179,17 @@ class VehicleSimulator:
         return rx, ry
 
 
+class SurfaceSensing:
+    def __init__(self,range_noise=0.01):
+        """Surfance Sensing Model
+        Obserbation point is uniformly included the vehicle
+        """
+        self.range_noise = range_noise
+
+    def get_observation_points(self, v_list, pointsnum):
+        for v in v_list:        
+            pass
+
 class LidarSimulator:
 
     def __init__(self,range_noise=0.01):
@@ -235,7 +245,7 @@ class LidarSimulator:
 
 
 
-def senario1():
+def senario1(tracker=None):
 
     sim = PerceptionSimulator(dt=0.2)
 
@@ -245,9 +255,9 @@ def senario1():
     sim.append_vehicle(v1)
 
 
-    l_shape_fitting = LShapeFitting()
+    fitting_func = tracker()
 
-    sim.run(l_shape_fitting)
+    sim.run(fitting_func)
     print("Done")
 
 

--- a/src/tracker/EKF_RectangleTracker.py
+++ b/src/tracker/EKF_RectangleTracker.py
@@ -53,7 +53,7 @@ class EKFRectangleTracker(ExtendedKalmanFilter):
 
     def measurement_process(self, z, dt):
 
-        Qnoise = self.motion_model.predict_noise_covariance(1e-2,1e-2,1e-1,dt)
+        Qnoise = self.motion_model.predict_noise_covariance(1e2,1e2,1e-1,dt)
         x_, P_ = self.predict_nonlinear(self.motion_model.predict, Qnoise, dt=dt)
         
         # reshape measurement as row vector

--- a/src/tracker/EKF_RectangleTracker.py
+++ b/src/tracker/EKF_RectangleTracker.py
@@ -106,6 +106,7 @@ def senario1():
     tracker.set_model()
     tracker.set_shape(5,3)
     tracker.set_pos([-10,0])
+    tracker.set_orientation_bicycle(np.pi/2)
 
     sim.run(tracker)
     print("Done")

--- a/src/tracker/EKF_RectangleTracker.py
+++ b/src/tracker/EKF_RectangleTracker.py
@@ -62,7 +62,7 @@ class EKFRectangleTracker(ExtendedKalmanFilter):
 
     def measurement_process(self, z, dt):
 
-        Qnoise = self.motion_model.predict_noise_covariance(1e2,1e-1,1e-9,dt)
+        Qnoise = self.motion_model.predict_noise_covariance(1e2,1e-1,1e-9,dt) #pos(acc) cov, rot cov, shape cov
         x_, P_ = self.predict_nonlinear(self.motion_model.predict, Qnoise, dt=dt)
         
         # reshape measurement as row vector
@@ -137,8 +137,8 @@ def senario1():
     sim = PerceptionSimulator(dt=0.1)
     v1 = VehicleSimulator(-10.0, 10.0, np.deg2rad(90.0),
                           0.0, 50.0 / 3.6, 3.0, 5.0)
-
-    sim.append_vehicle(v1)
+    vref = [0.1, 0]
+    sim.append_vehicle(v1,vref)
 
     tracker = EKFRectangleTracker()
     tracker.set_model()
@@ -149,6 +149,23 @@ def senario1():
     sim.run(tracker)
     print("Done")
 
+def senario2():
+    sim = PerceptionSimulator(dt=0.1)
+    v1 = VehicleSimulator(-10.0, 30.0, np.deg2rad(90.0),
+                          0.0, 50.0 / 3.6, 3.0, 5.0)
+    vref = [-0.1, 0]
+    sim.append_vehicle(v1,vref)
+
+    tracker = EKFRectangleTracker()
+    tracker.set_model()
+    tracker.set_shape(6,4)
+    tracker.set_pos([-10,30])
+    tracker.set_orientation(np.pi/2)
+
+    sim.run(tracker)
+    print("Done")
+
 
 if __name__=="__main__":
-    senario1()
+    #senario1()
+    senario2()

--- a/src/tracker/EKF_RectangleTracker.py
+++ b/src/tracker/EKF_RectangleTracker.py
@@ -1,0 +1,115 @@
+"""
+Rectangle Shape Tracker with Pure EKF
+
+
+http://liu.diva-portal.org/smash/get/diva2:434601/FULLTEXT02.pdf
+
+
+Yoshi Ri
+2022/08/18
+"""
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../")
+
+import numpy as np
+from utils import RectangleData
+from EKF import ExtendedKalmanFilter
+from RectangleTracker import *
+
+from simulator import PerceptionSimulator, VehicleSimulator
+
+
+class EKFRectangleTracker(ExtendedKalmanFilter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.x = np.array([0.0]*7).reshape(-1,1) 
+        self.P = np.diag([1e9]*7)
+        self.set_shape(1,1) # shape should larger than 0
+        self.sensor_noise =1e-1
+        self.dt = 1e-1
+
+    def set_sampling_time(self,dt):
+        self.dt = dt
+
+    def set_pos(self,pose):
+        self.x[0] = pose[0]
+        self.x[1] = pose[1]
+
+    def set_vel(self,vel):
+        self.x[2] = vel
+
+    def set_orientation_bicycle(self,orientation, wheel_angle = None):
+        self.x[3] = orientation
+        self.x[4] = wheel_angle if not wheel_angle is None else 0
+
+    def set_shape(self,length,width):
+        self.x[5] = length
+        self.x[6] = width
+
+    def set_model(self,motion_model=ConstantVelocityModel):
+        self.motion_model = motion_model()
+
+    def measurement_process(self, z, dt):
+
+        Qnoise = self.motion_model.predict_noise_covariance(1e-2,1e-2,1e-1,dt)
+        x_, P_ = self.predict_nonlinear(self.motion_model.predict, Qnoise, dt=dt)
+        
+        # reshape measurement as row vector
+        measurements = np.array(z).reshape(-1,1)
+
+        if len(z) > 0:
+            Rnoise = np.diag([self.sensor_noise]*len(z)*2)
+            self.update_nonlinear(x_, P_, get_estimated_rectangular_points,measurements, Rnoise, measurements=measurements)
+        else:
+            self.x = x_
+            self.P = P_
+
+    
+    def fitting(self,ox,oy):
+        """This function is needed to run simulation 
+
+        Args:
+            ox (_type_): x coordinate of lidar observation
+            oy (_type_): y coordinate of lidar observation
+            dt (_type_): sampling tme
+            tau (int, optional): tuning parameter for shape prediction agility. larger tau make shape estimation faster. Defaults to 2.
+            process_noise (int, optional): Random acceleration for object [m/s/s].  Defaults to 10.
+
+        Returns:
+            shape_obj, associated_ids 
+        """
+        dt = self.dt
+        assert len(ox)==len(oy), "Measurement must have same number of x and y axis value."
+        z = [[x,y] for x,y in zip(ox,oy)]
+
+        self.measurement_process(z,dt)
+        shape = RectangleData()
+        shape.center = self.x[0:2]
+        shape.length = self.x[5]
+        shape.width = self.x[6]
+        shape.orientation = self.x[4]
+        ids = np.arange(0, len(ox))
+        return [shape], [ids]
+
+
+
+def senario1():
+    sim = PerceptionSimulator(dt=0.1)
+    v1 = VehicleSimulator(-10.0, 0.0, np.deg2rad(90.0),
+                          0.0, 50.0 / 3.6, 3.0, 5.0)
+
+    sim.append_vehicle(v1)
+
+    tracker = EKFRectangleTracker()
+    tracker.set_model()
+    tracker.set_shape(5,3)
+    tracker.set_pos([-10,0])
+
+    sim.run(tracker)
+    print("Done")
+
+
+if __name__=="__main__":
+    senario1()

--- a/src/tracker/EKF_RectangleTracker.py
+++ b/src/tracker/EKF_RectangleTracker.py
@@ -25,7 +25,7 @@ class EKFRectangleTracker(ExtendedKalmanFilter):
     def __init__(self) -> None:
         super().__init__()
         self.x = np.array([0.0]*7).reshape(-1,1) 
-        self.P = np.diag([1e9]*7)
+        self.P = np.diag([1e4,1e4,1e9,1e2,1e9,1e2,1e2])
         self.set_shape(1,1) # shape should larger than 0
         self.sensor_noise =1e-1
         self.dt = 1e-1

--- a/src/tracker/LshapeFitting.py
+++ b/src/tracker/LshapeFitting.py
@@ -23,6 +23,7 @@ import itertools
 from enum import Enum
 
 from utils import rot_mat_2d
+from simulator import PerceptionSimulator, VehicleSimulator
 
 show_animation = True
 
@@ -172,7 +173,7 @@ class LShapeFitting:
 
         return S
 
-
+# override
 class RectangleData:
 
     def __init__(self):
@@ -205,9 +206,19 @@ class RectangleData:
         y = (a[1] * -c[0] - a[0] * -c[1]) / (a[0] * b[1] - a[1] * b[0])
         return x, y
 
-def main():
-    RectangleData()
+
+def senario1():
+    sim = PerceptionSimulator(dt=0.1)
+    v1 = VehicleSimulator(-10.0, 0.0, np.deg2rad(90.0),
+                          0.0, 50.0 / 3.6, 3.0, 5.0)
+
+    sim.append_vehicle(v1)
+
+    tracker = LShapeFitting()
+
+    sim.run(tracker)
+    print("Done")
 
 
-if __name__ == '__main__':
-    main()
+if __name__=="__main__":
+    senario1()

--- a/src/tracker/RectangleTracker.py
+++ b/src/tracker/RectangleTracker.py
@@ -36,7 +36,7 @@ def init_rectangle(state):
     """
     rs = RectangleShapePrediction()
     state = state.reshape(-1)
-    rs.orientation = state[4]
+    rs.orientation = state[3]
     rs.center = np.array([state[0], state[1]]).reshape(-1,1)
     rs.length = state[5]
     rs.width = state[6]

--- a/src/tracker/RectangleTracker.py
+++ b/src/tracker/RectangleTracker.py
@@ -3,6 +3,7 @@
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../")
+import logging
 
 import numpy as np
 from utils import rot_mat_2d, vec2rad, rad_distance
@@ -267,6 +268,7 @@ class RectangleShapePrediction():
             coords_ = self.get_equally_divided_coords(div_num,self.length,self.width)
             coords = center + np.transpose(R90 @ coords_.T)
         else:
+            logging.error()
             coords =  None
         return coords
     

--- a/src/tracker/RectangleTracker.py
+++ b/src/tracker/RectangleTracker.py
@@ -259,13 +259,13 @@ class RectangleShapePrediction():
             coords = center + coords_
         elif indx == 1:
             coords_ = self.get_equally_divided_coords(div_num,self.length,self.width)
-            coords = np.transpose(R90.T @ coords_.T)
+            coords = center + np.transpose(R90.T @ coords_.T)
         elif indx == 2:
             coords_ = self.get_equally_divided_coords(div_num,self.width,self.length)
-            coords = np.transpose(R180 @ coords_.T)
+            coords = center + np.transpose(R180 @ coords_.T)
         elif indx == 3:
             coords_ = self.get_equally_divided_coords(div_num,self.length,self.width)
-            coords = np.transpose(R90 @ coords_.T)
+            coords = center + np.transpose(R90 @ coords_.T)
         else:
             coords =  None
         return coords

--- a/src/tracker/RectangleTracker.py
+++ b/src/tracker/RectangleTracker.py
@@ -27,6 +27,11 @@ def get_estimated_rectangular_points(state,measurements):
             idx = rs_obj.find_closest_angle(nvec_rad,2) # this could be None when nvec_rad is not good
             em = rs_obj.divide_coords(pm.shape[0],idx)
             estimated_measurements = np.vstack([estimated_measurements,em]) if estimated_measurements.size else em
+        
+        # When N = 3 (corner is duplicated)
+        if estimated_measurements.shape[0] == Z.shape[0]+1:
+            estimated_measurements = np.delete(estimated_measurements,corner_index, axis=0) # remove duplicated corner
+
     return estimated_measurements.reshape(-1,1)
 
 
@@ -150,7 +155,7 @@ def find_corner_index(measurements):
     elif d_a_mean > d_b_mean:
         parted_measurements = [measurements[:corner_index], measurements[corner_index:]]
     else:
-        parted_measurements = [measurements[:corner_index+1], measurements[corner_index:]]
+        parted_measurements = [measurements[:corner_index+1], measurements[corner_index:]] # this is happened when N = 3
     return corner_index, parted_measurements
 
 

--- a/src/tracker/RectangleTracker.py
+++ b/src/tracker/RectangleTracker.py
@@ -78,7 +78,8 @@ def estimate_number_of_sides(measurements,threshold=25):
     Z = np.array(measurements).reshape(-1,2)
     Nz = Z.shape[0]
 
-    if Nz == 1:
+    if Nz < 3:
+        # This has edge case: when N = 2 and there are only one measurement point in each side 
         N = 1
     else:
         Zbar = np.mean(Z,axis=0)

--- a/src/tracker/RectangleTracker.py
+++ b/src/tracker/RectangleTracker.py
@@ -25,7 +25,7 @@ def get_estimated_rectangular_points(state,measurements):
         corner_index, parted_measurements = find_corner_index(Z)
         for pm in parted_measurements:
             nvec_rad = measurements_normalvec_angle(pm)
-            idx = rs_obj.find_closest_angle(nvec_rad,2) # this could be None when nvec_rad is not good
+            idx = rs_obj.find_closest_angle(nvec_rad) # this could be None when nvec_rad is not good
             em = rs_obj.divide_coords(pm.shape[0],idx)
             estimated_measurements = np.vstack([estimated_measurements,em]) if estimated_measurements.size else em
         
@@ -187,7 +187,7 @@ class RectangleShapePrediction():
         n_vecs = [self.orientation , self.orientation - np.pi/2, self.orientation + np.pi, self.orientation + np.pi/2]
         return n_vecs
     
-    def find_closest_angle(self,angle_rad, threshold=0.5):
+    def find_closest_angle(self,angle_rad, threshold=0.25*np.pi):
         """find closest direction
 
         Args:
@@ -268,7 +268,7 @@ class RectangleShapePrediction():
             coords_ = self.get_equally_divided_coords(div_num,self.length,self.width)
             coords = center + np.transpose(R90 @ coords_.T)
         else:
-            logging.error()
+            logging.error("indx: " + str(indx))
             coords =  None
         return coords
     

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,7 +15,9 @@ def rad_distance(a1,a2):
     while dist >= 2*np.pi:
         dist -= 2*np.pi
     if np.abs(dist) > np.pi:
-        min_dist  = 2*np.pi - np.abs(dist)  
+        min_dist  = 2*np.pi - np.abs(dist)
+    else:
+        min_dist = dist
     return min_dist
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,7 +14,9 @@ def rad_distance(a1,a2):
     dist = np.abs(a1 - a2)
     while dist >= 2*np.pi:
         dist -= 2*np.pi
-    return dist
+    if np.abs(dist) > np.pi:
+        min_dist  = 2*np.pi - np.abs(dist)  
+    return min_dist
 
 
 # numerical gradient input: func must be a function and x is vector 

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,8 +62,8 @@ class RectangleData:
         """Return rectangle contour"""
         R = rot_mat_2d(self.orientation) 
         center = np.array(self.center).reshape(-1,1)
-        v1 = np.array([self.width/2, self.length/2]).reshape(-1,1)
-        v2 = np.array([self.width/2, -self.length/2]).reshape(-1,1)
+        v1 = np.array([self.length/2, self.width/2]).reshape(-1,1)
+        v2 = np.array([self.length/2, -self.width/2]).reshape(-1,1)
         c1 = R @ v1 + center
         c2 = R @ v2 + center
         c3 = -R @ v1 + center

--- a/src/utils.py
+++ b/src/utils.py
@@ -34,6 +34,6 @@ def numerical_jacob(func, x, **other_args):
     Jacob = np.array([])
     for i in range(N):
         grad_ = numerical_grad(func,x,i,**other_args)
-        grad = grad_.reshape(1,-1)
-        Jacob = np.vstack([Jacob,grad]) if Jacob.size else grad
+        grad = grad_.reshape(-1,1)
+        Jacob = np.hstack([Jacob,grad]) if Jacob.size else grad
     return Jacob

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,23 +17,23 @@ def rad_distance(a1,a2):
 
 
 # numerical gradient input: func must be a function and x is vector 
-def numerical_grad(func, x, i, eps=1e-9, *other_args):
+def numerical_grad(func, x, i, eps=1e-9, **other_args):
     x_arr = np.array(x,dtype=float).reshape(-1)
     x_p, x_m = deepcopy(x_arr), deepcopy(x_arr)
     r_eps = max(np.abs(x_m[i])*eps, eps)
     x_m[i] -= r_eps
     x_p[i] += r_eps
-    fp = func(x_p, *other_args)
-    fm = func(x_m, *other_args)
+    fp = func(x_p, **other_args)
+    fm = func(x_m, **other_args)
     grad = (fp-fm)/r_eps/2
     return grad
 
-def numerical_jacob(func, x, *other_args):
+def numerical_jacob(func, x, **other_args):
     x = np.array(x).reshape(-1)
     N = len(x)
     Jacob = np.array([])
     for i in range(N):
-        grad_ = numerical_grad(func,x,i,*other_args)
+        grad_ = numerical_grad(func,x,i,**other_args)
         grad = grad_.reshape(1,-1)
         Jacob = np.vstack([Jacob,grad]) if Jacob.size else grad
     return Jacob

--- a/src/utils.py
+++ b/src/utils.py
@@ -47,20 +47,36 @@ from matplotlib.patches import Ellipse, Rectangle
 
 class RectangleData:
 
-    def __init__(self, plot_color="red"):
+    def __init__(self, plot_setting="-.r"):
         self.center = [None]*2
         self.width = None
         self.length = None
         self.orientation = None
-        self.plot_color = plot_color
+        self.plot_setting = plot_setting
+
+    def calc_contour(self):
+        """Return rectangle contour"""
+        R = rot_mat_2d(self.orientation) 
+        center = np.array(self.center).reshape(-1,1)
+        v1 = np.array([self.length/2, self.width/2]).reshape(-1,1)
+        v2 = np.array([self.length/2, -self.width/2]).reshape(-1,1)
+        c1 = R @ v1 + center
+        c2 = R @ v2 + center
+        c3 = -R @ v1 + center
+        c4 = -R @ v2 + center
+        contour = np.hstack([c1,c2,c3,c4,c1]).T
+        return contour
+
+    def draw_rect(self):
+        """draw rectangle contour and center without rectangle patch"""
+        contour = self.calc_contour()
+        plt.plot(contour[:,0],contour[:,1],self.plot_setting)
+        plt.plot(self.center[0],self.center[1],'ko')
+
 
     def plot(self):
         ax = plt.gca()
-        rshape = Rectangle([self.center[0], self.center[1]], self.length, self.width,
-                    angle = np.rad2deg(self.orientation),
-                    edgecolor=self.plot_color,
-                    facecolor='none')
-        ax.add_patch(rshape)
+        self.draw_rect()
 
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -58,8 +58,8 @@ class RectangleData:
         """Return rectangle contour"""
         R = rot_mat_2d(self.orientation) 
         center = np.array(self.center).reshape(-1,1)
-        v1 = np.array([self.length/2, self.width/2]).reshape(-1,1)
-        v2 = np.array([self.length/2, -self.width/2]).reshape(-1,1)
+        v1 = np.array([self.width/2, self.length/2]).reshape(-1,1)
+        v2 = np.array([self.width/2, -self.length/2]).reshape(-1,1)
         c1 = R @ v1 + center
         c2 = R @ v2 + center
         c3 = -R @ v1 + center

--- a/tests/test_EKF.py
+++ b/tests/test_EKF.py
@@ -10,6 +10,8 @@ def test_EKF():
     P_init = np.diag([1e9,1e9])
     ekf.init_state(x_init,P_init)
 
+
+    # prediction test
     def sample_predict(x, y=None, dt=0):
         x_ = np.copy(x)
         x_[0] = x_[1]*dt
@@ -20,4 +22,11 @@ def test_EKF():
     x_,P_ =  ekf.predict_nonlinear(sample_predict,Q,None,dt=dt)
 
     assert x_[0] == ekf.x[0] + ekf.x[1] *dt
-    
+
+    # measurement test 
+    def sample_measurement(x):
+        z = x[0] * x[1]
+        return z
+
+    Rnoise = np.diag([0.02])
+    ekf.update_nonlinear(x_, P_, sample_measurement, [0.1], Rnoise)

--- a/tests/test_EKF.py
+++ b/tests/test_EKF.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def test_EKF():
     ekf = ExtendedKalmanFilter()
-    x_init = np.array([0.,0.]).reshape(-1,1)
+    x_init = np.array([0.,1.]).reshape(-1,1)
     P_init = np.diag([1e9,1e9])
     ekf.init_state(x_init,P_init)
 
@@ -16,4 +16,8 @@ def test_EKF():
         return x_
 
     Q = np.diag([0.1,0.1])
-    ekf.predict_nonlinear(sample_predict,Q,None,dt=0.1)
+    dt = 0.1
+    x_,P_ =  ekf.predict_nonlinear(sample_predict,Q,None,dt=dt)
+
+    assert x_[0] == ekf.x[0] + ekf.x[1] *dt
+    

--- a/tests/test_EKF.py
+++ b/tests/test_EKF.py
@@ -1,3 +1,5 @@
+from random import sample
+from this import d
 import pytest
 from src.EKF import ExtendedKalmanFilter
 import numpy as np
@@ -7,3 +9,11 @@ def test_EKF():
     x_init = np.array([0.,0.]).reshape(-1,1)
     P_init = np.diag([1e9,1e9])
     ekf.init_state(x_init,P_init)
+
+    def sample_predict(x, y=None, dt=0):
+        x_ = np.copy(x)
+        x_[0] = x_[1]*dt
+        return x_
+
+    Q = np.diag([0.1,0.1])
+    ekf.predict_nonlinear(sample_predict,Q,None,dt=0.1)

--- a/tests/test_RectangleTracker.py
+++ b/tests/test_RectangleTracker.py
@@ -1,6 +1,13 @@
 import pytest
 from src.tracker.RectangleTracker import *
 
+
+def test_get_estimated_rectangular_points():
+    Z = [[0,1],[0,0],[1,0],[2,0],[3,0]]
+    state = np.array([0,0,0,0,0,1,0.5]).reshape(-1,1)
+    get_estimated_rectangular_points(state,Z)
+    
+
 def test_measurement_normalvec_angle():
     Z1 = [[0,0],[0,1]]
     Z2 = [[0,-1],[0,-1]]

--- a/tests/test_RectangleTracker.py
+++ b/tests/test_RectangleTracker.py
@@ -6,7 +6,7 @@ def test_get_estimated_rectangular_points():
     Z = [[0,1],[0,0],[1,0],[2,0],[3,0]]
     state = np.array([0,0,0,0,0,1,0.5]).reshape(-1,1)
     get_estimated_rectangular_points(state,Z)
-    
+
 
 def test_measurement_normalvec_angle():
     Z1 = [[0,0],[0,1]]
@@ -48,3 +48,22 @@ def test_coords_divide():
     right = rsp.divide_coords(3,1)[1]         # take center point
     estimated_right = np.array([rsp.width/2,0])
     assert np.allclose(right, estimated_right) # array_equal sometimes fail due to calc error
+
+
+def test_Bicycle_model():
+    bmm = BicycleMotionModel()
+    x = np.array([0.]*7)
+    x[5] = 2
+    x[6] = 1
+    x_ = bmm.predict(x, dt=0.1)
+    x[3] = 1
+    x[4] = 0.5
+    x_ = bmm.predict(x, dt=0.1)
+    
+
+def test_Simple_model():
+    bmm = ConstantVelocityModel()
+    x = np.array([0.]*7)
+    x[5] = 2
+    x[6] = 1
+    x_ = bmm.predict(x, dt=0.1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,3 +29,39 @@ def test_numerical_jacob():
     J = numerical_jacob(func,X0)
     assert np.allclose(J,d_func(X0)) 
     
+
+def test_ellipsoid(showflag=False):
+    shape = EllipsoidData()
+    shape.init_with_param([0,0],10,8,30)
+    if showflag:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        shape.plot()
+        plt.xlim([-20,20])
+        plt.ylim([-20,20])
+        plt.grid()
+    
+    Cov=shape.calc_ellipse_matrix(100,64,np.deg2rad(30))
+    shape.init_with_cov([0,0],Cov)
+    if showflag:
+        plt.figure()
+        shape.plot()
+        plt.xlim([-20,20])
+        plt.ylim([-20,20])
+        plt.grid()
+        plt.show()
+
+
+def test_rectangle(showflag=False):
+    shape = RectangleData()
+    shape.center = [0,0]
+    shape.width = 1
+    shape.length = 2
+    shape.orientation = 0.2
+
+    if showflag:
+        plt.figure(1)
+        plt.xlim([-20,20])
+        plt.ylim([-20,20])
+        shape.plot()
+        plt.show()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,7 @@ def test_numerical_grad():
 
 def test_numerical_jacob():
     func = lambda x: x[0]*x[0] + np.cos(x[1])
-    d_func = lambda x: np.array( [2*x[0],-np.sin(x[1])]).reshape(-1,1)
+    d_func = lambda x: np.array( [2*x[0],-np.sin(x[1])]).reshape(1,-1)
     X0 = np.array([1.0,0.5]).reshape(-1,1)
 
     J = numerical_jacob(func,X0)


### PR DESCRIPTION
# abstract

Create rectangle shape tracker based on EKF.

- Corner detection/measurement split
- measurements point prediction with uniformly aligned assumption
- EKF based pose and shape tracker

See [granstrom, 2011](http://liu.diva-portal.org/smash/get/diva2:434601/FULLTEXT02.pdf).


## senario check

- [x] straight motion(close->far)
- [x] straight motion(far->close)
- [ ] rotation motion
  - [x] one side estimation
  - [ ] two side estimation

## Test results

```
---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
tests/test_EKF.py                   43      0   100%
tests/test_RectangleTracker.py      52      0   100%
tests/test_utils.py                 54     17    69%
----------------------------------------------------
TOTAL                              149     17    89%
```